### PR TITLE
fix: propogate OLLAMA_URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       WATSONX_REGION: ${WATSONX_REGION}
       BAM_API_KEY: ${BAM_API_KEY:-dummy}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-dummy}
+      OLLAMA_URL: ${OLLAMA_URL:-dummy}
 
       MONGODB_URL: mongodb://mongo:27017?directConnection=true
       MONGODB_DATABASE_NAME: bee-api


### PR DESCRIPTION
Propagates ollama configuration variables from docker-compose .env file into api container
 - OLLAMA_HOST
 - OLLAMA_MODEL
 
 As well as these being passed into containers such as bee-api with the same name, I also added a setting for:
  - OLLAMA_URL (this is used in the bee API, and uses the OLLAMA_HOST .env entry)
  
 
 Confirmed variable propagation working via:
 ```
 ➜  bee-stack git:(issue9) docker exec 356b70ee7143 env | grep OLLAMA
OLLAMA_HOST=http://host.containers.internal:11434
OLLAMA_MODEL=llama3.2:latest
```

Fixes: #9

end-end test.

With ollama running locally, and llama3.1:8b and nomic-embed-text installed, Using a config of:
```
LLM_BACKEND=ollama
EMBEDDING_BACKEND=ollama
OLLAMA_HOST=http://host.containers.internal:11434
OLLAMA_MODEL="llama3.1:8b"
```

I was able to run the bee sample agent, ask some simple questions, see tasks (like web searches) executed and explained.

For reviewers
* I know there are changes in the environment variables used. In particular I had to set OLLAMA_URL (within the yml) as well as OLLAMA_HOST so that the bee api inherited the correct config
* Are there specific tests/checked recommended for any PR fix?
* If this change is reasonable, I could add some docs on using with podman on mac in some form of README - probably as a followup PR?

