### PR TITLE
chore(docs): Info on using local resources/troubleshooting podman macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,31 @@ docker compose --profile all down --volumes
 
 ## Advanced 👷
 
+### Development
 If you are a developer on `bee-api` or `bee-ui` and want to run only the supporting infrastructure,
 use the profile `infra`, e.g.:
 
 ```shell
 docker compose --profile infra up -d
+```
+### Connecting to host resources
+
+There are many networking options in both [Podman](https://github.com/containers/podman/blob/main/docs/tutorials/basic_networking.md) and [Docker](https://docs.docker.com/engine/network/)
+
+The bee stack does not explicitly configure a network, so by default typically a bridge network is generated automatically. Additionally a specific host name is made available to the container which represents the host. This can be used to access other services on that host, such as ollama running locally.
+
+The hostnames are:
+* host.containers.internal (podman)
+* host.docker.internal (docker)
+
+Below is an example `.env` configuration for a podman environment which will allow the bee stack to connect back to ollama running on the host
+```
+LLM_BACKEND=ollama
+EMBEDDING_BACKEND=ollama
+WATSONX_PROJECT_ID=
+WATSONX_API_KEY=
+WATSONX_REGION=us-south
+OLLAMA_URL=http://host.containers.internal:11434
 ```
 
 # Contributing


### PR DESCRIPTION
Two suggestions for readme as a followon to PR #10

* Adds section on accessing local resources on the container host 

I've added links to the reference docs, and given an example of hostnames that work in the default case. However there are many potential combinations... 

I've also added an explicit config example - this depends on the earlier PR being an acceptable fix.

* Added troubleshooting section

I hit issues with podman-compose, and added workaround to the readme. One other option is to consider removal of the ulimit spec in compose, but at least by adding a doc note that could be considered separately 