### PR TITLE
[WIP] add initial helm chart

### DIFF
--- a/charts/bee-stack/.helmignore
+++ b/charts/bee-stack/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/bee-stack/Chart.lock
+++ b/charts/bee-stack/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: mongodb
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 16.2.1
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 20.1.7
+- name: milvus
+  repository: https://milvus-io.github.io/milvus-helm
+  version: 4.0.31
+- name: mlflow
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.0.4
+digest: sha256:3acc8fc41a07cbffc1b52ae6861dc9df69ccd7aed99752deb00b5074e915b97c
+generated: "2024-11-01T11:40:56.896103-04:00"

--- a/charts/bee-stack/Chart.yaml
+++ b/charts/bee-stack/Chart.yaml
@@ -1,0 +1,46 @@
+apiVersion: v2
+name: bee-stack
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"
+
+dependencies:
+- name: mongodb
+  condition: mongodbEnable
+  version: 16.2.1
+  repository: oci://registry-1.docker.io/bitnamicharts
+
+- name: redis
+  condition: redisEnable
+  version: 20.1.7
+  repository: https://charts.bitnami.com/bitnami
+
+- name: milvus
+  condition: milvusEnable
+  version: 4.0.31
+  repository: https://milvus-io.github.io/milvus-helm
+
+- name: mlflow
+  condition: mlflowEnable
+  version: 2.0.4
+  repository: oci://registry-1.docker.io/bitnamicharts
+

--- a/charts/bee-stack/templates/agent-deployment.yaml
+++ b/charts/bee-stack/templates/agent-deployment.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-bee-stack
+  labels:
+    app.kubernetes.io/name: bee-stack
+    app.kubernetes.io/instance: agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bee-stack
+      app.kubernetes.io/instance: agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bee-stack
+        app.kubernetes.io/instance: agent
+    spec:
+      serviceAccountName: bee-stack-agent
+      containers:
+        - name: bee-stack-agent
+          image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
+          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          command: ["/bin/sh"]
+          args: ["-c", "output=$(npx mikro-orm seeder:run 2>&1); echo \"$$output\"; if ! (echo \"$$output\" | grep -qiE \"already seeded|success\"); then echo \"Error occured\" && exit 1; fi && node --enable-source-maps ./dist/server.js"]
+          env:
+            - name: LLM_BACKEND
+              value: "{{ .Values.agent.llm.llm_backend }}"
+            - name: EMBEDDING_BACKEND
+              value: "{{ .Values.agent.llm.embedding_backend }}"
+            - name: WATSONX_PROJECT_ID
+              value: "{{ .Values.agent.llm.watsonx_project_id }}"
+            - name: WATSONX_API_KEY
+              value: "{{ .Values.agent.llm.watsonx_api_key }}"
+            - name: BAM_API_KEY
+              value: "{{ .Values.agent.llm.bam_api_key }}"
+            - name: OPENAI_API_KEY
+              value: "{{ .Values.agent.llm.openai_api_key }}"
+
+            - name: MONGODB_URL
+              value: "mongodb://{{ .Release.Name }}-mongodb-headless:27017?directConnection=true"
+            - name: MONGODB_DATABASE_NAME
+              value: bee-api
+            - name: REDIS_URL
+              value: "redis://{{ .Release.Name }}-redis-master:6379/0"
+            - name: REDIS_CACHE_URL
+              value: "redis://{{ .Release.Name }}-redis-master:6379/8"
+            - name: AUTH_JWKS_URI
+              value: "http://localhost:4000/v1/ui/jwks"
+            - name: AUTH_JWT_ISSUER
+              value: "https://localhost"
+            - name: AUTH_JWT_AUDIENCE
+              value: bee-test
+            - name: HTTP_PROXY_URL
+              value: "http://localhost:3128"
+            - name: BEE_CODE_INTERPRETER_URL
+              value: "http://bee-code-interpreter-k3s:30051"
+
+            - name: BEE_CODE_INTERPRETER_STORAGE_BACKEND
+              value: filesystem
+            - name: BEE_CODE_INTERPRETER_FILE_STORAGE_PATH
+              value: "/storage"
+            - name: SHUTDOWN_GRACEFUL_PERIOD
+              value: "1"
+
+            - name: S3_ENDPOINT
+              value: "http://minio:9000"
+            - name: S3_ACCESS_KEY_ID
+              value: minioadmin
+            - name: S3_SECRET_ACCESS_KEY
+              value: minioadmin
+            - name: S3_BUCKET_FILE_STORAGE
+              value: bee-api
+
+            - name: BEE_OBSERVE_API_URL
+              value: "http://bee-stack-observe:3000"
+            - name: BEE_OBSERVE_API_AUTH_KEY
+              value: observe-auth-key
+
+            - name: MILVUS_HOST
+              value: milvus
+            - name: MILVUS_PORT
+              value: "19530"
+            - name: MILVUS_USE_TLS
+              value: "false"
+            - name: MILVUS_USERNAME
+              value: user
+            - name: MILVUS_PASSWORD
+              value: password
+            - name: MILVUS_DATABASE_NAME
+              value: default
+
+            - name: RUN_BULLMQ_WORKERS
+              value: "runs,runs:cleanup,vectorStores:cleanup,vectorStores:fileProcessor,files:extraction"
+
+            - name: CRYPTO_CIPHER_KEY
+              value: random_crypto_key
+            - name: OTEL_SDK_DISABLED
+              value: "true"
+
+            - name: USER_ID_DEFAULT
+              value: dummy
+            - name: PROJECT_ID_DEFAULT
+              value: proj_670cc04869ddffe24f4fd70f
+            - name: ORGANIZATION_ID_DEFAULT
+              value: org_670cc04869ddffe24f4fd70d
+            - name: ORGANIZATION_OWNER_ID_DEFAULT
+              value: dummy
+            - name: PROJECT_ADMIN_ID_DEFAULT
+              value: dummy
+            - name: AUTH_CLIENT_ID
+              value: dummy
+            - name: AUTH_CLIENT_SECRET
+              value: dummy
+            - name: AUTH_SERVER_PORT
+              value: "4001"
+            - name: AUTH_WELL_KNOWN
+              value: "http://127.0.0.1:4001/.well-known/openid-configuration"
+            - name: AUTH_AUDIENCE
+              value: bee-test
+          ports:
+            - name: http
+              containerPort: 4000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+          #volumeMounts:
+          #  - mountPath: /storage
+          #    name: code-interpreter-storage
+          #    readOnly: false
+#      volumes:
+#        - name: code-interpreter-storage
+#          secret:
+#            optional: false
+#            secretName: mysecret

--- a/charts/bee-stack/templates/agent-sa.yaml
+++ b/charts/bee-stack/templates/agent-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bee-stack-agent
+automountServiceAccountToken: true

--- a/charts/bee-stack/templates/agent-svc.yaml
+++ b/charts/bee-stack/templates/agent-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bee-stack-agent
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4000
+      targetPort: 4000
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: bee-stack
+    app.kubernetes.io/instance: agent

--- a/charts/bee-stack/templates/observe-deployment.yaml
+++ b/charts/bee-stack/templates/observe-deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: observe-bee-stack
+  labels:
+    app.kubernetes.io/name: bee-stack
+    app.kubernetes.io/instance: observe
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bee-stack
+      app.kubernetes.io/instance: observe
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bee-stack
+        app.kubernetes.io/instance: observe
+    spec:
+      serviceAccountName: bee-stack-agent
+      containers:
+        - name: bee-stack-observe
+          image: "{{ .Values.observe.image.repository }}:{{ .Values.observe.image.tag }}"
+          imagePullPolicy: {{ .Values.observe.image.pullPolicy }}
+          command: ["/bin/sh"] 
+          args: ["-c",  "npx mikro-orm --config dist/mikro-orm.config.js migration:up && node ./dist/index.js"]
+          env:
+            - name: PORT
+              value: "3000"
+            - name: AUTH_KEY
+              value: observe-auth-key
+            - name: FASTIFY_BODY_LIMIT
+              value: "10485760"
+            - name: REDIS_URL
+              value: redis://{{ .Release.Name }}-redis-master:6379/1
+            - name: MONGODB_URL
+              value: mongodb://{{ .Release.Name }}-mongodb-headless:27017?directConnection=true
+            - name: DATA_EXPIRATION_IN_DAYS
+              value: "7"
+            - name: MLFLOW_API_URL
+              value: http://{{ .Release.Name }}-mlflow-tracking:80/
+            - name: MLFLOW_DEFAULT_EXPERIMENT_ID
+              value: "0"
+            - name: MLFLOW_AUTHORIZATION
+              value: BASE_AUTH
+            - name: MLFLOW_USERNAME
+              value: user
+            - name: MLFLOW_PASSWORD
+              value: password
+            - name: MLFLOW_TRACE_DELETE_IN_BATCHES_CRON_PATTERN
+              value: "0 */1 * * * *"
+            - name: MLFLOW_TRACE_DELETE_IN_BATCHES_BATCH_SIZE
+              value: "100"
+            - name: NODE_ENV
+              value: production
+

--- a/charts/bee-stack/templates/observe-svc.yaml
+++ b/charts/bee-stack/templates/observe-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bee-stack-observe
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: bee-stack
+    app.kubernetes.io/instance: observe

--- a/charts/bee-stack/templates/ui-deployment.yaml
+++ b/charts/bee-stack/templates/ui-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ui-bee-stack
+  labels:
+    app.kubernetes.io/name: bee-stack
+    app.kubernetes.io/instance: ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bee-stack
+      app.kubernetes.io/instance: ui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bee-stack
+        app.kubernetes.io/instance: ui
+    spec:
+      serviceAccountName: bee-stack-agent
+      containers:
+        - name: bee-stack-ui
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          env:
+            - name: NEXTAUTH_URL
+              value: http://bee-stack-ui:3000
+            - name: NEXTAUTH_SECRET
+              value: top-secret
+            - name: API_URL
+              value: http://bee-stack-agent:4000
+            - name: DUMMY_JWT_TOKEN
+              value: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0IiwicHJlZmVycmVkX3VzZXJuYW1lIjoiVGVzdCBVc2VyIiwiZW1haWwiOiJ0ZXN0QGVtYWlsLmNvbSIsImlhdCI6MTUxNjIzOTAyMiwiaXNzIjoiaHR0cHM6Ly9sb2NhbGhvc3QiLCJhdWQiOiJiZWUtdGVzdCJ9.vwkGnl7lBbzJYk6BtoW3VoA3mnNJVI-nDQU8aK7zOH-rkf2pn5cn6CKwpq7enDInIXro8WtBLNZP8Nr8GQIZKahICuP3YrPRmzv7YIW8LuXKnx1hycg5OAtj0OtQi5FYwwCxTYW9pBF2it7XwQSBcW7yYsOrvgs7jVhThCOsavX0YiAROxZIhk1idZT4Pl3egfUI_dy9iBxcn7xocTnos-94wqJNt8oCVgB8ynj75yJFHJbiQ-9Tym_V3LcMHoEyv67Jzie8KugCgdpuF6EbQqcyfYJ83q5jJpR2LiuWMuGsNSbjjDY-f1vCSMo9L9-R8KFrDylT_BzLvRBswOzW7A
+          ports:
+          - containerPort: 3000
+            name: http
+            protocol: TCP

--- a/charts/bee-stack/templates/ui-svc.yaml
+++ b/charts/bee-stack/templates/ui-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bee-stack-ui
+spec:
+  type: NodePort
+  #type: ClusterIP
+  ports:
+    - port: 3000
+      # targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: bee-stack
+    app.kubernetes.io/instance: ui

--- a/charts/bee-stack/values.yaml
+++ b/charts/bee-stack/values.yaml
@@ -1,0 +1,103 @@
+# Default values for bee-stack.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+agent:
+  image:
+    repository: "iambeeagent/bee-api"
+    pullPolicy: IfNotPresent
+    tag: "0.0.5"
+  llm:
+    llm_backend: watsonx
+    embedding_backend: watsonx 
+    watsonx_project_id:
+    watsonx_api_key:
+    bam_api_key: dummy
+    openai_api_key: dummy
+ui:
+  image:
+    repository: "iambeeagent/bee-ui-local"
+    pullPolicy: IfNotPresent
+    tag: "0.0.2"
+observe:
+  image:
+    repository: "iambeeagent/bee-observe"
+    pullPolicy: IfNotPresent
+    tag: "0.0.3"
+#
+#  mondodb configurations
+#
+mongodbEnable: true
+mongodb:
+  architecture: replicaset
+  image:
+    repository: xavidop/mongodb
+    tag: '7.0'
+  auth:
+    enabled: false
+  arbiter:
+    enabled: false
+  replicaCount: 1
+  
+#
+#  redis configurations
+#
+redisEnable: true
+redis:
+  architecture: standalone
+  auth:
+    enabled: false
+    sentinel: false
+  tls:
+    authClients: false
+#
+#  milvus configurations
+#
+milvusEnable: true
+milvus:
+  metrics:
+    enabled: false
+  proxy:
+    enabled: false
+  rootCoordinator:
+    enabled: false
+  queryCoordinator:
+    enabled: false
+  queryNode:
+    enabled: false
+  indexCoordinator:
+    enabled: false
+  indexNode:
+    enabled: false
+  dataCoordinator:
+    enabled: false
+  dataNode:
+    enabled: false
+  mixCoordinator:
+    enabled: false
+  attu:
+    enabled: true
+  minio:
+    enabled: true
+    mode: standalone
+  etcd:
+    enabled: true
+    replicaCount: 1
+  pulsar:
+    enabled: false
+#
+#  mlflow configurations
+#
+mlflowEnable: true
+mlflow:
+  tracking:
+    enabled: true
+    auth:
+      username: user
+      password: password
+  run:
+    enabled: false
+  postgresql:
+    enabled: true
+  minio:
+    enabled: false


### PR DESCRIPTION
Create helm chart to install bee-stack in kubernetes cluster.

The bee-api, bee-ui and bee-observ are in the main chart and the other dependency components are in the sub charts.

Necessary tools are:
1. kubernetes cluster. (kind, RancherDesctop, etc)
2. kubectl
3. helm 

Install step:
1. cd to `charts/bee-stack`
4. run `helm dependency update`
5. run 'helm install "release name" .` 

The stack is install in the default namespace.

uninstall step:
1. run 'helm uninstall "release name"`
2. run `kubectl delete pvc` for an necessary PVC.  
