### PR TITLE
feat(compose): configure ports for code over http

### DIFF
--- a/bee-code-interpreter.yaml
+++ b/bee-code-interpreter.yaml
@@ -38,6 +38,7 @@ spec:
       image: icr.io/i-am-bee/bee-code-interpreter:0.0.27
       ports:
         - containerPort: 50051
+        - containerPort: 8000
       env:
         - name: APP_EXECUTOR_IMAGE
           value: icr.io/i-am-bee/bee-code-executor:0.0.27
@@ -64,5 +65,10 @@ spec:
     - port: 50051
       targetPort: 50051
       nodePort: 30051
+      name: grpc
+    - port: 50081
+      targetPort: 8000
+      nodePort: 30081
+      name: http
   selector:
     app: code-interpreter

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,7 @@ services:
       - ./bee-code-interpreter.yaml:/var/lib/rancher/k3s/server/manifests/bee-code-interpreter.yaml
     ports:
       - "50051:30051"
+      - "50081:30081"
     healthcheck:
       test: "kubectl get pod code-interpreter | grep Running"
       interval: 10s


### PR DESCRIPTION
The code interpreter is currently being used with gRPC, but HTTP is also available. Need to configure compose to allow us to add (switch to) code tool over HTTP with more ports.

Closes: #53 