### PR TITLE
feat: add log collection command

### DIFF
--- a/.github/ISSUE_TEMPLATE/run_stack_issue.md
+++ b/.github/ISSUE_TEMPLATE/run_stack_issue.md
@@ -1,0 +1,26 @@
+---
+name: Issue running bee-stack
+about: Create a report to help us improve bee-stack
+title: ""
+labels: debug
+assignees: ""
+---
+
+**Tasks**
+
+- [ ] I have run through the
+  [troubleshooting guide](https://github.com/i-am-bee/bee-stack/blob/main/docs/troubleshooting.md)
+- [ ] My container provider (docker / podman / rancher) and the compose extension are up to date
+  (`docker compose version` or `podman compose version` returns a version >= `2.26`)
+
+
+**Description**
+<!--
+Describe the issue you have
+-->
+
+**Logs**
+<!--
+Please upload logs by running `./bee-stack.sh logs` and uploading the resulting file here. The log
+will be located in `./logs`, for example `./logs/2024-11-27_1549S.zip`
+-->

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Once started you can find use the following URLs:
 ##  ⛓️‍💥 Troubleshooting
 Please see our [troubleshoting guide](docs/troubleshooting.md) for help with the most common issues.
 
+> If you run through the troubleshooting guide and bee-stack is still crashing, please collect
+> the logs using `./bee-stack.sh logs` and submit them to a new issue at:
+> https://github.com/i-am-bee/bee-agent-framework/issues/new?template=run_stack_issue.md
+
 ## 👷 Advanced
 
 ### Custom models

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,7 +258,7 @@ services:
       MILVUS_URL: milvus:19530
     ports:
       - 19531:3000
-    profiles: [ all, infra ]
+    profiles: [ infra ]
 volumes:
   etcd:
   minio:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,9 @@
 # Common issues
 
+> If you run through the troubleshooting guide and bee-stack is still crashing, please collect
+> the logs using `./bee-stack.sh logs` and submit them to a new issue at:
+> https://github.com/i-am-bee/bee-agent-framework/issues/new?template=run_stack_issue.md
+
 ### ERROR: None of compose command versions meets the required version
 
 If you get this error message, you have a compose provider installed, but it's not the correct version.


### PR DESCRIPTION
Ref: #51 

Added `./bee-stack.sh logs` command to collect and package logs. User is then instructed to create an issue
and upload them:


```sh
$ ./bee-stack.sh logs
  adding: logs/2024-11-27_1834S/ (stored 0%)
  adding: logs/2024-11-27_1834S/minio.log (deflated 63%)
  adding: logs/2024-11-27_1834S/bee-code-interpreter-k3s.log (deflated 86%)
  adding: logs/2024-11-27_1834S/redis.log (stored 0%)
  adding: logs/2024-11-27_1834S/mongo.log (deflated 92%)
  adding: logs/2024-11-27_1834S/milvus.log (deflated 86%)
  adding: logs/2024-11-27_1834S/bee-api.log (deflated 81%)
  adding: logs/2024-11-27_1834S/bee-observe.log (deflated 88%)
  adding: logs/2024-11-27_1834S/bee-ui.log (deflated 39%)
  adding: logs/2024-11-27_1834S/mlflow.log (deflated 70%)
  adding: logs/2024-11-27_1834S/docker.log (stored 0%)
  adding: logs/2024-11-27_1834S/etcd.log (deflated 76%)
Logs were created in ./logs/2024-11-27_1834S.
If you have issues running bee-stack, please create an issue and attach the file ./logs/2024-11-27_1834S.zip at:
https://github.com/i-am-bee/bee-stack/issues/new?template=run_stack_issue.md
```