### PR TITLE
automate docker network config for ollama on linux

### DIFF
--- a/bee-stack.sh
+++ b/bee-stack.sh
@@ -236,9 +236,7 @@ start_stack() {
   if grep -q TEXT_EXTRACTION_ENABLED=true .env; then
     ${RUNTIME} compose --profile text-extraction up -d
   fi
-  # if [ "$(uname)" = "Linux" ]; then
   if [ "$(uname)" = "Linux" ] && grep -q AI_BACKEND="ollama" .env; then
-    printf "set host.docker.internal"
     docker exec bee-stack-bee-api-1 sh -c "echo \"\$(ip route | awk '/default/ { print \$3 }' | head -n 1)      host.docker.internal\" | tee -a /etc/hosts > /dev/null"
   fi
   printf "Done. You can visit the UI at ${BLUE}http://localhost:3000${NC}\n"


### PR DESCRIPTION
I've automated the linux ollama setup issue mentioned here:
https://github.com/i-am-bee/bee-stack/blob/main/docs/troubleshooting.md#connecting-to-ollama-on-linux
This change affects configure_ollama() and the start_stack()

**configure_ollama**
in case the the OS is Linux and the OLLAMA_URL is the default, the ollama check also updates 
the /etc/hosts on the fly there for the command can succeed if ollama is binded to 0.0.0.0 on the host OS.

**start_stack**
updates the /etc/hosts in bee-stack-bee-api-1 

Manually tested on 
Linux version 6.1.0-28-amd64 (debian-kernel@lists.debian.org) (gcc-12 (Debian 12.2.0-14) 12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22)
Docker version 20.10.24+dfsg1, build 297e128



